### PR TITLE
Update pixel-art class to work with Firefox.

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -13,8 +13,8 @@ body {
 }
 
 img.pixel-art {
-  image-rendering:-webkit-optimize-contrast; /* Safari */
-  image-rendering:pixelated;                 /* Chrome */
+  image-rendering:-moz-crisp-edges; /* Firefox */
+  image-rendering:pixelated;        /* Chrome */
 }
 
 /* card content */


### PR DESCRIPTION
Problem: Images look fuzzy on Firefox.

Firefox stable does not yet support `image-rendering:pixelated;`.
https://bugzilla.mozilla.org/show_bug.cgi?id=856337

Solution: Update pixel-art class have `image-rendering:-moz-crisp-edges; ` for Firefox.

Also, the latest version of Safari no longer requires the -webkit prefix, so
remove that, too.