### PR TITLE
Use @nox.session decorator for test sessions.

### DIFF
--- a/nox.py
+++ b/nox.py
@@ -3,10 +3,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import nox
 
-def session_freeze(session):
-    # Install all development dependencies.
-    session.install('-r', 'requirements.txt')
+
+@nox.session
+def translations(session):
+    session.install('Babel')
 
     # Extract messages and compile all translations.
     # https://github.com/whogoesfirst/who-goes-first/blob/master/docs/TRANSLATING.md
@@ -21,17 +23,25 @@ def session_freeze(session):
         '.')
     session.run(
         'pybabel', 'update', '-i', 'messages.pot', '-d', './translations')
-    session.run('pybabel', 'compile', '-d', './translations')
+
+
+@nox.session
+def freeze(session):
+    # Install all development dependencies.
+    session.install('-r', 'requirements.txt')
 
     # Freeze the app.
     # This should fail if there are any redirects, 404s, or server errors.
+    session.run('pybabel', 'compile', '-d', './translations')
     session.run('python', 'freeze.py')
 
 
-def session_lint(session):
+@nox.session
+def lint(session):
     session.install('flake8')
     session.run('flake8', '--exclude', '.nox,.cache,env', '.')
 
 
-def session_js(session):
+@nox.session
+def js(session):
     session.run('npm', 'test')


### PR DESCRIPTION
Problem: Translation was running too often, causing unnecessary merge conflicts.

Solution: With the use of the decorator, nox will run the sessions in the order
they are defined. This means I can skip the translations session when no
text is changing, but it runs by default in the appropriate order
(before freeze).